### PR TITLE
LPS-152793 - Searching for articles in the recycle bin does not show any results when the portal is not set to english

### DIFF
--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexer.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexer.java
@@ -14,6 +14,7 @@
 
 package com.liferay.trash.internal.search;
 
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.search.BaseIndexer;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
@@ -35,6 +36,7 @@ import com.liferay.trash.model.TrashEntry;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
@@ -133,14 +135,35 @@ public class TrashIndexer extends BaseIndexer<TrashEntry> {
 			return;
 		}
 
-		addSearchLocalizedTerm(searchQuery, searchContext, Field.CONTENT, true);
-		addSearchLocalizedTerm(
-			searchQuery, searchContext, Field.DESCRIPTION, true);
 		addSearchTerm(
 			searchQuery, searchContext, Field.REMOVED_BY_USER_NAME, true);
-		addSearchLocalizedTerm(searchQuery, searchContext, Field.TITLE, true);
 		addSearchTerm(searchQuery, searchContext, Field.TYPE, false);
 		addSearchTerm(searchQuery, searchContext, Field.USER_NAME, true);
+
+		Set<Locale> supportLocales = LanguageUtil.getAvailableLocales();
+
+		long[] groupIds = searchContext.getGroupIds();
+
+		if ((groupIds != null) && (groupIds.length > 0)) {
+			supportLocales = LanguageUtil.getAvailableLocales(groupIds[0]);
+		}
+
+		for (Locale locale : supportLocales) {
+			String localizedTitle = Field.getLocalizedName(locale, Field.TITLE);
+
+			String localizedDescription = Field.getLocalizedName(
+				locale, Field.DESCRIPTION);
+
+			String localizedContent = Field.getLocalizedName(
+				locale, Field.CONTENT);
+
+			addSearchTerm(searchQuery, searchContext, localizedTitle, true);
+
+			addSearchTerm(
+				searchQuery, searchContext, localizedDescription, true);
+
+			addSearchTerm(searchQuery, searchContext, localizedContent, true);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
**Steps to reproduce**

1. Start Liferay DXP U22
2. Log in to liferay
3. Edit the home page, add a language selector widget to the home page, publish
4. Set english as the language
5. Create a web content article with the title "recycled" and publish it.
6. Move the article to the recycle bin
7. Open the recycle bin and search for "recycled" -> the article is found
8. Change the language to german
9. Open the recycle bin and search for "recycled"

**Expected Result:**

The article is found

**Actual Result:**

No results are shown for german

**Solution:**
Currently, the search context is set to the most relevant locale, which is related to the selected language on the homepage. 
However, when creating an article, title, body, and description en_US are required but other locales are optional, some translation fields might be null when the article is created that's why the recycle bin does not show any results when the portal is not set to English.	
I add some more query criteria if the current locale is different from than site's default locale

https://issues.liferay.com/browse/LPS-152793